### PR TITLE
Update Log.php

### DIFF
--- a/system/core/Log.php
+++ b/system/core/Log.php
@@ -178,8 +178,8 @@ class CI_Log {
 
 		$level = strtoupper($level);
 
-		if (( ! isset($this->_levels[$level]) OR ($this->_levels[$level] > $this->_threshold))
-			&& ! isset($this->_threshold_array[$this->_levels[$level]]))
+		if ( ! isset($this->_levels[$level])
+			|| ($this->_levels[$level] > $this->_threshold && ! isset($this->_threshold_array[$this->_levels[$level]])))
 		{
 			return FALSE;
 		}


### PR DESCRIPTION
Fix bug on validation of $level that does not exist.
If !isset($this->_levels[$level] then the validation of  $this->_threshold_array[$this->_levels[$level] throw an exception.